### PR TITLE
Listen on ipv6 as well as ipv4

### DIFF
--- a/templates/smtpd.conf.tmpl
+++ b/templates/smtpd.conf.tmpl
@@ -1,4 +1,5 @@
 listen on 0.0.0.0
+listen on ::
 
 table aliases file:/etc/smtpd/aliases
 


### PR DESCRIPTION
Currently the container only listens on ipv4; it should listen on both ipv4 and ipv6. Tested on my local cluster.