### PR TITLE
Add RELAY_SCHEME environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Supported tags and respective `Dockerfile` links:
 | `OPENSMTPD_EXPIRE`           | `4d`          |             |
 | `OPENSMTPD_MAX_MESSAGE_SIZE` | `35M`         |             |
 | `RELAY_HOST`                 |               |             |
-| `RELAY_SCHEME`               | `smtp+tls`    |             |
+| `RELAY_PROTO`               | `smtp+tls`    |             |
 | `RELAY_USER`                 |               |             |
 | `RELAY_PASSWORD`             |               |             |
 | `RELAY_PORT`                 | `587`         |             |

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Supported tags and respective `Dockerfile` links:
 | `OPENSMTPD_EXPIRE`           | `4d`          |             |
 | `OPENSMTPD_MAX_MESSAGE_SIZE` | `35M`         |             |
 | `RELAY_HOST`                 |               |             |
+| `RELAY_SCHEME`               | `smtp+tls`    |             |
 | `RELAY_USER`                 |               |             |
 | `RELAY_PASSWORD`             |               |             |
 | `RELAY_PORT`                 | `587`         |             |

--- a/templates/smtpd.conf.tmpl
+++ b/templates/smtpd.conf.tmpl
@@ -12,10 +12,10 @@ smtp max-message-size {{ getenv "OPENSMTPD_MAX_MESSAGE_SIZE" "35M" }}
 {{ if getenv "RELAY_HOST" }}
 {{ if getenv "RELAY_USER" }}
 table authinfo db:/etc/smtpd/authinfo.db
-action default relay host "smtp+tls://user@{{ getenv "RELAY_HOST" }}:{{ getenv "RELAY_PORT" "587" }}" auth <authinfo>
+action default relay host "{{ getenv "RELAY_SCHEME" "smtp+tls" }}://user@{{ getenv "RELAY_HOST" }}:{{ getenv "RELAY_PORT" "587" }}" auth <authinfo>
 match from any for any action default
 {{ else }}
-action default relay host "smtp+tls://{{ getenv "RELAY_HOST" }}:{{ getenv "RELAY_PORT" "587" }}"
+action default relay host "{{ getenv "RELAY_SCHEME" "smtp+tls" }}://{{ getenv "RELAY_HOST" }}:{{ getenv "RELAY_PORT" "587" }}"
 match from any for any action default
 {{ end }}
 {{ else }}

--- a/templates/smtpd.conf.tmpl
+++ b/templates/smtpd.conf.tmpl
@@ -12,10 +12,10 @@ smtp max-message-size {{ getenv "OPENSMTPD_MAX_MESSAGE_SIZE" "35M" }}
 {{ if getenv "RELAY_HOST" }}
 {{ if getenv "RELAY_USER" }}
 table authinfo db:/etc/smtpd/authinfo.db
-action default relay host "{{ getenv "RELAY_SCHEME" "smtp+tls" }}://user@{{ getenv "RELAY_HOST" }}:{{ getenv "RELAY_PORT" "587" }}" auth <authinfo>
+action default relay host "{{ getenv "RELAY_PROTO" "smtp+tls" }}://user@{{ getenv "RELAY_HOST" }}:{{ getenv "RELAY_PORT" "587" }}" auth <authinfo>
 match from any for any action default
 {{ else }}
-action default relay host "{{ getenv "RELAY_SCHEME" "smtp+tls" }}://{{ getenv "RELAY_HOST" }}:{{ getenv "RELAY_PORT" "587" }}"
+action default relay host "{{ getenv "RELAY_PROTO" "smtp+tls" }}://{{ getenv "RELAY_HOST" }}:{{ getenv "RELAY_PORT" "587" }}"
 match from any for any action default
 {{ end }}
 {{ else }}


### PR DESCRIPTION
Hi,
A small modification to add the RELAY_SCHEME variable that allow to change the scheme used (typically, switching from smtp+tls to smtp). By default, smtp+tls is still used.