### PR TITLE
Add support for file-provided password

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,33 @@ Supported tags and respective `Dockerfile` links:
 | `OPENSMTPD_EXPIRE`           | `4d`          |             |
 | `OPENSMTPD_MAX_MESSAGE_SIZE` | `35M`         |             |
 | `RELAY_HOST`                 |               |             |
-| `RELAY_PROTO`               | `smtp+tls`    |             |
+| `RELAY_PROTO`                | `smtp+tls`    |             |
 | `RELAY_USER`                 |               |             |
+| `RELAY_USER_FILE`            |               | A file where the user can be found |
 | `RELAY_PASSWORD`             |               |             |
+| `RELAY_PASSWORD_FILE`        |               | A file where the password can be found |
 | `RELAY_PORT`                 | `587`         |             |
+
+The XXX_FILE environment variables allow to put the authentication
+credentials in files rather than environment variables directly.
+This is typically used to deploy the authentication password using
+`docker secret`.
+
+If you store the password in `docker secret`, e.g.
+
+```
+$ echo 'my secret' | docker secreat create smtp_relay_password -
+```
+
+then you can use it setting the `RELAY_PASSWORD_FILE` environment
+variable in your container like:
+
+```
+RELAY_PASSWORD_FILE=/run/secrets/smtp_relay_password`
+```
+
+Note that you cannot specify both the `XXX` and `XXX_FILE` environment
+variables.
 
 ## Orchestration actions
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,6 +8,36 @@ fi
 
 chmod 711 /var/spool/smtpd
 
+# The code of the file_env() function has been borrowed from
+# https://github.com/ix-ai/smtp/blob/master/entrypoint.sh
+# It is licensed under the MIT License, Copyright (c) 2018 Namshi
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both ${var} and ${fileVar} are set (but are mutually exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+# retrieve these 2 env vars from file, if any (typically used to deploy
+# the password using docker secret)
+file_env RELAY_USER
+file_env RELAY_PASSWORD
+
 gotpl /etc/gotpl/smtpd.conf.tmpl > /etc/smtpd/smtpd.conf
 
 if [[ -n "${RELAY_USER}" ]]; then


### PR DESCRIPTION
Allow the user to configure the user and password for the relay authentication credentials using files instead of environment variables. This allows to deploy such a password using `docker secret`.